### PR TITLE
Fix: Reduce visibility of protected class members to private

### DIFF
--- a/module/Application/src/Application/Controller/ContributorsController.php
+++ b/module/Application/src/Application/Controller/ContributorsController.php
@@ -13,12 +13,12 @@ class ContributorsController extends AbstractActionController
     /**
      * @var RepositoryRetriever
      */
-    protected $repositoryRetriever;
+    private $repositoryRetriever;
 
     /**
      * @var array
      */
-    protected $repositoryData;
+    private $repositoryData;
 
     /**
      * @param RepositoryRetriever $repositoryRetriever


### PR DESCRIPTION
This PR
- [x] reduces the visibility of class members of `Controller\ContributorsController` from `protected`to `private`
