### PR TITLE
Fix: GitHubRepositoryUrl view helper

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -135,7 +135,7 @@ return [
     'view_helpers' => [
         'factories' => [
             'sanitizeHtml' => View\Helper\SanitizeHtmlFactory::class,
-            'githubRepositoryUrl' => View\Helper\GitHubRepositoryUrlFactory::class,
+            'gitHubRepositoryUrl' => View\Helper\GitHubRepositoryUrlFactory::class,
         ],
     ],
 ];

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
@@ -37,7 +37,11 @@ class GitHubRepositoryUrl extends AbstractHelper
     public function __invoke()
     {
         if (null === $this->url) {
-            $this->url = sprintf('https://github.com/%s/%s', $this->owner, $this->name);
+            $this->url = sprintf(
+                'https://github.com/%s/%s',
+                $this->owner,
+                $this->name
+            );
         }
 
         return $this->url;

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
@@ -27,8 +27,8 @@ class GitHubRepositoryUrl extends AbstractHelper
      */
     public function __construct($owner, $name)
     {
-        $this->owner = $owner;
-        $this->name = $name;
+        $this->owner = (string) $owner;
+        $this->name = (string) $name;
     }
 
     /**

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
@@ -9,17 +9,17 @@ class GitHubRepositoryUrl extends AbstractHelper
     /**
      * @var string
      */
-    protected $owner;
+    private $owner;
 
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var string
      */
-    protected $url;
+    private $url;
 
     /**
      * @param string $owner

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrl.php
@@ -36,7 +36,7 @@ class GitHubRepositoryUrl extends AbstractHelper
      */
     public function __invoke()
     {
-        if ($this->url === null) {
+        if (null === $this->url) {
             $this->url = sprintf('https://github.com/%s/%s', $this->owner, $this->name);
         }
 

--- a/module/Application/test/ApplicationTest/Integration/View/Helper/GitHubRepositoryUrlTest.php
+++ b/module/Application/test/ApplicationTest/Integration/View/Helper/GitHubRepositoryUrlTest.php
@@ -18,7 +18,7 @@ class GitHubRepositoryUrlTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             Helper\GitHubRepositoryUrl::class,
-            $viewHelperManager->get('githubRepositoryUrl')
+            $viewHelperManager->get('gitHubRepositoryUrl')
         );
     }
 }

--- a/module/Application/test/ApplicationTest/Integration/View/Helper/GitHubRepositoryUrlTest.php
+++ b/module/Application/test/ApplicationTest/Integration/View/Helper/GitHubRepositoryUrlTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ApplicationTest\Integration\View\Helper;
+
+use Application\View\Helper;
+use ApplicationTest\Integration\Util\Bootstrap;
+use PHPUnit_Framework_TestCase;
+use Zend\View\HelperPluginManager;
+
+class GitHubRepositoryUrlTest extends PHPUnit_Framework_TestCase
+{
+    public function testServiceCanBeRetrieved()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        /* @var HelperPluginManager $viewHelperManager */
+        $viewHelperManager = $serviceManager->get('ViewHelperManager');
+
+        $this->assertInstanceOf(
+            Helper\GitHubRepositoryUrl::class,
+            $viewHelperManager->get('githubRepositoryUrl')
+        );
+    }
+}

--- a/module/Application/test/ApplicationTest/Mock/StringCastable.php
+++ b/module/Application/test/ApplicationTest/Mock/StringCastable.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ApplicationTest\Mock;
+
+class StringCastable
+{
+    private $value;
+
+    public function __construct($string)
+    {
+        $this->value = $string;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/module/Application/test/ApplicationTest/View/Helper/GitHubRepositoryUrlTest.php
+++ b/module/Application/test/ApplicationTest/View/Helper/GitHubRepositoryUrlTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ApplicationTest\View\Helper;
+
+use Application\View\Helper;
+use PHPUnit_Framework_TestCase;
+
+class GitHubRepositoryUrlTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeReturnsUrl()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $url = sprintf(
+            'https://github.com/%s/%s',
+            $owner,
+            $name
+        );
+
+        $helper = new Helper\GitHubRepositoryUrl(
+            $owner,
+            $name
+        );
+
+        $this->assertSame($url, $helper());
+    }
+}

--- a/module/Application/test/ApplicationTest/View/Helper/GitHubRepositoryUrlTest.php
+++ b/module/Application/test/ApplicationTest/View/Helper/GitHubRepositoryUrlTest.php
@@ -3,6 +3,7 @@
 namespace ApplicationTest\View\Helper;
 
 use Application\View\Helper;
+use ApplicationTest\Mock\StringCastable;
 use PHPUnit_Framework_TestCase;
 use ReflectionObject;
 
@@ -47,5 +48,30 @@ class GitHubRepositoryUrlTest extends PHPUnit_Framework_TestCase
         $reflectionProperty->setValue($helper, $url);
 
         $this->assertSame($url, $helper());
+    }
+
+    public function testConstructorCastsArgumentsToString()
+    {
+        $owner = new StringCastable('foo');
+        $name = new StringCastable('bar');
+
+        $helper = new Helper\GitHubRepositoryUrl(
+            $owner,
+            $name
+        );
+
+        $properties = [
+            'owner' => $owner,
+            'name' => $name,
+        ];
+
+        $reflectionObject = new ReflectionObject($helper);
+
+        array_walk($properties, function ($value, $name) use ($reflectionObject, $helper) {
+            $reflectionProperty = $reflectionObject->getProperty($name);
+            $reflectionProperty->setAccessible(true);
+
+            $this->assertSame((string) $value, $reflectionProperty->getValue($helper));
+        });
     }
 }

--- a/module/Application/test/ApplicationTest/View/Helper/GitHubRepositoryUrlTest.php
+++ b/module/Application/test/ApplicationTest/View/Helper/GitHubRepositoryUrlTest.php
@@ -4,6 +4,7 @@ namespace ApplicationTest\View\Helper;
 
 use Application\View\Helper;
 use PHPUnit_Framework_TestCase;
+use ReflectionObject;
 
 class GitHubRepositoryUrlTest extends PHPUnit_Framework_TestCase
 {
@@ -22,6 +23,28 @@ class GitHubRepositoryUrlTest extends PHPUnit_Framework_TestCase
             $owner,
             $name
         );
+
+        $this->assertSame($url, $helper());
+    }
+
+    public function testInvokeLazilyCreatesUrl()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $url = 'https://example.org';
+
+        $helper = new Helper\GitHubRepositoryUrl(
+            $owner,
+            $name
+        );
+
+        $reflectionObject = new ReflectionObject($helper);
+
+        $reflectionProperty = $reflectionObject->getProperty('url');
+        $reflectionProperty->setAccessible(true);
+
+        $reflectionProperty->setValue($helper, $url);
 
         $this->assertSame($url, $helper());
     }

--- a/module/Application/view/application/contributors/index.phtml
+++ b/module/Application/view/application/contributors/index.phtml
@@ -9,7 +9,7 @@
             <strong><?php echo $this->escapeHtml($this->metadata->stargazers_count); ?> stargazers</strong>,
             <strong><?php echo $this->escapeHtml($this->metadata->watchers_count); ?> watchers</strong> and
             <strong>awesome contributors</strong> who make this site better.
-            <a href="<?php echo $this->escapeHtmlAttr($this->githubRepositoryUrl()); ?>" target="_blank">Join us!</a>
+            <a href="<?php echo $this->escapeHtmlAttr($this->gitHubRepositoryUrl()); ?>" target="_blank">Join us!</a>
         </p>
         <?php foreach ($this->contributors as $contributor): ?>
             <?php $url = $contributor['author']['html_url']; ?>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -85,7 +85,7 @@
                         <div>
                             <p>
                                 If you are interested in helping with this project, simply fork the code on
-                                <a class="zf-green" href="<?php echo $this->escapeHtmlAttr($this->githubRepositoryUrl()); ?>" target="_blank">GitHub</a>
+                                <a class="zf-green" href="<?php echo $this->escapeHtmlAttr($this->gitHubRepositoryUrl()); ?>" target="_blank">GitHub</a>
                                 and get started!
                             </p>
                             <p>


### PR DESCRIPTION
This PR
- [x] adds integration and unit tests for `View\Helper\GitHubRepositoryUrl`
- [x] brings the service identifier in line with the class name (`githubRepositoryUrl` vs. `gitHubRepositoryUrl`) and updates places where it is used
- [x] flips values in a condition
- [x] casts constructor arguments to `string`

See https://github.com/zendframework/modules.zendframework.com/pull/447#discussion_r25640916.
