### PR TITLE
Enhancement: Add tests for new functionality in RepositoryRetriever

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "bjyoungblood/BjyProfiler": "1.1.0",
         "fabpot/php-cs-fixer": "~1.4",
+        "fzaninotto/faker": "^1.4.0",
         "phpunit/phpunit": "4.0.*",
         "zendframework/zend-developer-tools": "dev-master",
         "zendframework/zftool": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "63ea636b6c7c4d69f8682e5b8d7cde6e",
+    "hash": "5b568b757cd77278ea941d309b8b65d7",
     "packages": [
         {
             "name": "evandotpro/edp-github",
@@ -870,6 +870,54 @@
             ],
             "description": "A script to automatically fix Symfony Coding Standard",
             "time": "2015-02-18 19:35:59"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "010c7efedd88bf31141a02719f51fb44c732d5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/010c7efedd88bf31141a02719f51fb44c732d5a0",
+                "reference": "010c7efedd88bf31141a02719f51fb44c732d5a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-0": {
+                    "Faker": "src/",
+                    "Faker\\PHPUnit": "test/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2014-06-04 14:43:02"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -3,15 +3,19 @@
 namespace ApplicationTest\Service;
 
 use Application\Service\RepositoryRetriever;
+use ApplicationTest\Util\FakerTrait;
 use EdpGithub;
 use EdpGithub\Api;
 use EdpGithub\Client;
 use EdpGithub\Collection;
 use EdpGithub\Listener\Exception;
 use PHPUnit_Framework_TestCase;
+use stdClass;
 
 class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
 {
+    use FakerTrait;
+
     public function testCanRetrieveUserRepositories()
     {
         $payload = [
@@ -232,6 +236,8 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
+        $response = json_encode($this->contributors(5));
+
         $repositoryApi
             ->expects($this->once())
             ->method('contributors')
@@ -239,7 +245,7 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
                 $this->equalTo($owner),
                 $this->equalTo($name)
             )
-            ->willReturn(json_encode([]))
+            ->willReturn($response)
         ;
 
         $client = $this->getMockBuilder(Client::class)
@@ -310,5 +316,36 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         ;
 
         return $client;
+    }
+
+    /**
+     * @link https://developer.github.com/v3/repos/#response-5
+     *
+     * @return stdClass
+     */
+    private function contributor()
+    {
+        $contributor = new stdClass();
+
+        $contributor->login = $this->faker()->unique()->userName;
+        $contributor->avatar_url = $this->faker()->unique()->url;
+        $contributor->html_url = $this->faker()->unique()->url;
+
+        return $contributor;
+    }
+
+    /**
+     * @param int $count
+     * @return stdClass[]
+     */
+    private function contributors($count)
+    {
+        $contributors = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            array_push($contributors, $this->contributor());
+        }
+
+        return $contributors;
     }
 }

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -318,6 +318,53 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         return $client;
     }
 
+    public function testGetContributorsHasDefaultLimitOf20()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $limit = 20;
+
+        $repositoryApi = $this->getMockBuilder(Api\Repos::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $response = json_encode($this->contributors(50));
+
+        $repositoryApi
+            ->expects($this->once())
+            ->method('contributors')
+            ->with(
+                $this->equalTo($owner),
+                $this->equalTo($name)
+            )
+            ->willReturn($response)
+        ;
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $client
+            ->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('repos'))
+            ->willReturn($repositoryApi)
+        ;
+
+        $service = new RepositoryRetriever($client);
+
+        $contributors = $service->getContributors(
+            $owner,
+            $name
+        );
+
+        $this->assertInternalType('array', $contributors);
+        $this->assertCount($limit, $contributors);
+    }
+
     /**
      * @link https://developer.github.com/v3/repos/#response-5
      *

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -365,6 +365,54 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         $this->assertCount($limit, $contributors);
     }
 
+    public function testGetContributorsAcceptsLimit()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $limit = 37;
+
+        $repositoryApi = $this->getMockBuilder(Api\Repos::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $response = json_encode($this->contributors(50));
+
+        $repositoryApi
+            ->expects($this->once())
+            ->method('contributors')
+            ->with(
+                $this->equalTo($owner),
+                $this->equalTo($name)
+            )
+            ->willReturn($response)
+        ;
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $client
+            ->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('repos'))
+            ->willReturn($repositoryApi)
+        ;
+
+        $service = new RepositoryRetriever($client);
+
+        $contributors = $service->getContributors(
+            $owner,
+            $name,
+            $limit
+        );
+
+        $this->assertInternalType('array', $contributors);
+        $this->assertCount($limit, $contributors);
+    }
+
     /**
      * @link https://developer.github.com/v3/repos/#response-5
      *

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -413,6 +413,57 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         $this->assertCount($limit, $contributors);
     }
 
+    public function testGetContributorsDecodesResponseToArray()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $repositoryApi = $this->getMockBuilder(Api\Repos::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $response = json_encode($this->contributors(10));
+
+        $repositoryApi
+            ->expects($this->once())
+            ->method('contributors')
+            ->with(
+                $this->equalTo($owner),
+                $this->equalTo($name)
+            )
+            ->willReturn($response)
+        ;
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $client
+            ->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('repos'))
+            ->willReturn($repositoryApi)
+        ;
+
+        $service = new RepositoryRetriever($client);
+
+        $contributors = $service->getContributors(
+            $owner,
+            $name
+        );
+
+        $this->assertInternalType('array', $contributors);
+
+        array_walk($contributors, function ($contributor) {
+            $this->assertInternalType('array', $contributor);
+            $this->assertArrayHasKey('login', $contributor);
+            $this->assertArrayHasKey('avatar_url', $contributor);
+            $this->assertArrayHasKey('html_url', $contributor);
+        });
+    }
+
     /**
      * @link https://developer.github.com/v3/repos/#response-5
      *

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -527,6 +527,44 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         });
     }
 
+    public function testGetContributorsReturnsFalseIfRuntimeExceptionIsThrown()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $repositoryApi = $this->getMockBuilder(Api\Repos::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $repositoryApi
+            ->expects($this->once())
+            ->method('contributors')
+            ->willThrowException(new Exception\RuntimeException())
+        ;
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $client
+            ->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('repos'))
+            ->willReturn($repositoryApi)
+        ;
+
+        $service = new RepositoryRetriever($client);
+
+        $contributors = $service->getContributors(
+            $owner,
+            $name
+        );
+
+        $this->assertFalse($contributors);
+    }
+
     /**
      * @link https://developer.github.com/v3/repos/#response-5
      *

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -5,6 +5,7 @@ namespace ApplicationTest\Service;
 use Application\Service\RepositoryRetriever;
 use EdpGithub;
 use EdpGithub\Api;
+use EdpGithub\Client;
 use EdpGithub\Collection;
 use EdpGithub\Listener\Exception;
 use PHPUnit_Framework_TestCase;
@@ -219,6 +220,46 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         $service = new RepositoryRetriever($clientMock);
         $response = $service->getUserRepositoryMetadata('foo', 'bar');
         $this->assertFalse($response);
+    }
+
+    public function testGetContributorsFetchesFromApi()
+    {
+        $owner = 'foo';
+        $name = 'bar';
+
+        $repositoryApi = $this->getMockBuilder(Api\Repos::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $repositoryApi
+            ->expects($this->once())
+            ->method('contributors')
+            ->with(
+                $this->equalTo($owner),
+                $this->equalTo($name)
+            )
+            ->willReturn(json_encode([]))
+        ;
+
+        $client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $client
+            ->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('repos'))
+            ->willReturn($repositoryApi)
+        ;
+
+        $service = new RepositoryRetriever($client);
+
+        $service->getContributors(
+            $owner,
+            $name
+        );
     }
 
     /**

--- a/module/Application/test/ApplicationTest/Util/FakerTrait.php
+++ b/module/Application/test/ApplicationTest/Util/FakerTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ApplicationTest\Util;
+
+use Faker\Factory;
+use Faker\Generator;
+
+trait FakerTrait
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    /**
+     * @return Generator
+     */
+    private function faker()
+    {
+        if (null === $this->faker) {
+            $this->faker = Factory::create('en_US');
+            $this->faker->seed(9000);
+        }
+
+        return $this->faker;
+    }
+}


### PR DESCRIPTION
This PR
- [x] requires [`fzaninotto/faker`](https://github.com/fzaninotto/Faker) as a dev dependency
- [x] implements a `FakerTrait` which provides a seeded `Faker\Generator`
- [x] adds missing tests for `Service\RepositoryRetriever`

See https://github.com/zendframework/modules.zendframework.com/pull/447#issuecomment-76831208.
