### PR TITLE
Fix: Maintain alphabetical order of service definitions

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -98,8 +98,8 @@ return [
     'controllers' => [
         'factories' => [
             Controller\IndexController::class => Controller\IndexControllerFactory::class,
-            Controller\SearchController::class => Controller\SearchControllerFactory::class,
             Controller\ContributorsController::class => Controller\ContributorsControllerFactory::class,
+            Controller\SearchController::class => Controller\SearchControllerFactory::class,
         ],
     ],
     'service_manager' => [
@@ -134,8 +134,8 @@ return [
     ],
     'view_helpers' => [
         'factories' => [
-            'sanitizeHtml' => View\Helper\SanitizeHtmlFactory::class,
             'gitHubRepositoryUrl' => View\Helper\GitHubRepositoryUrlFactory::class,
+            'sanitizeHtml' => View\Helper\SanitizeHtmlFactory::class,
         ],
     ],
 ];


### PR DESCRIPTION
This PR
- [x] keeps service definitions in alphabetical order

See https://github.com/zendframework/modules.zendframework.com/pull/447#discussion_r25689460.
